### PR TITLE
Inforigami.Regalo.SqlServer: Support for externally managed connection/transaction

### DIFF
--- a/Inforigami.Regalo.SqlServer/DbCommandExtensions.cs
+++ b/Inforigami.Regalo.SqlServer/DbCommandExtensions.cs
@@ -1,0 +1,33 @@
+using System.Data;
+using System.Data.Common;
+
+namespace Inforigami.Regalo.SqlServer
+{
+    internal static class DbCommandExtensions
+    {
+        public static DbParameter AddParameter(this DbCommand command, string name, DbType dbType, int size)
+        {
+            var parameter = command.AddParameter(name, dbType);
+            parameter.Size = size;
+            return parameter;
+        }
+
+        public static DbParameter AddParameter(this DbCommand command, string name, DbType dbType)
+        {
+            var parameter = command.CreateParameter();
+            parameter.ParameterName = name;
+            parameter.DbType = dbType;
+            command.Parameters.Add(parameter);
+            return parameter;
+        }
+
+        public static DbParameter AddParameterWithValue(this DbCommand command, string name, object value)
+        {
+            var parameter = command.CreateParameter();
+            parameter.ParameterName = name;
+            parameter.Value = value;
+            command.Parameters.Add(parameter);
+            return parameter;
+        }
+    }
+}

--- a/Inforigami.Regalo.SqlServer/ExternalSqlSession.cs
+++ b/Inforigami.Regalo.SqlServer/ExternalSqlSession.cs
@@ -1,9 +1,9 @@
-using Microsoft.Data.SqlClient;
+using System.Data.Common;
 
 namespace Inforigami.Regalo.SqlServer
 {
     /// <summary>
-    /// Represents a <see cref="SqlConnection" /> and <see cref="SqlTransaction" /> that are externally controlled.
+    /// Represents a <see cref="DbConnection" /> and <see cref="DbTransaction" /> that are externally controlled.
     /// </summary>
     /// <remarks>
     /// It is the responsibility of the external owner to manage and dispose of the connection and transaction.
@@ -11,17 +11,17 @@ namespace Inforigami.Regalo.SqlServer
     /// </remarks>
     public sealed class ExternalSqlSession : ISqlSession
     {
-        public ExternalSqlSession(SqlConnection connection, SqlTransaction transaction)
+        public ExternalSqlSession(DbConnection connection, DbTransaction transaction)
         {
             Connection = connection;
             Transaction = transaction;
         }
 
         /// <inheritdoc />
-        public SqlConnection Connection { get; }
+        public DbConnection Connection { get; }
 
         /// <inheritdoc />
-        public SqlTransaction Transaction { get; }
+        public DbTransaction Transaction { get; }
 
         /// <inheritdoc />
         public void Complete()

--- a/Inforigami.Regalo.SqlServer/ExternalSqlSession.cs
+++ b/Inforigami.Regalo.SqlServer/ExternalSqlSession.cs
@@ -1,0 +1,36 @@
+using Microsoft.Data.SqlClient;
+
+namespace Inforigami.Regalo.SqlServer
+{
+    /// <summary>
+    /// Represents a <see cref="SqlConnection" /> and <see cref="SqlTransaction" /> that are externally controlled.
+    /// </summary>
+    /// <remarks>
+    /// It is the responsibility of the external owner to manage and dispose of the connection and transaction.
+    /// The <see cref="Complete" /> and <see cref="Dispose" /> methods do nothing.
+    /// </remarks>
+    public sealed class ExternalSqlSession : ISqlSession
+    {
+        public ExternalSqlSession(SqlConnection connection, SqlTransaction transaction)
+        {
+            Connection = connection;
+            Transaction = transaction;
+        }
+
+        /// <inheritdoc />
+        public SqlConnection Connection { get; }
+
+        /// <inheritdoc />
+        public SqlTransaction Transaction { get; }
+
+        /// <inheritdoc />
+        public void Complete()
+        {
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/Inforigami.Regalo.SqlServer/ISqlSession.cs
+++ b/Inforigami.Regalo.SqlServer/ISqlSession.cs
@@ -1,23 +1,22 @@
 using System;
-
-using Microsoft.Data.SqlClient;
+using System.Data.Common;
 
 namespace Inforigami.Regalo.SqlServer
 {
     /// <summary>
-    /// Provides access to an already open <see cref="SqlConnection" /> and <see cref="SqlTransaction" />.
+    /// Provides access to an already open <see cref="DbConnection" /> and <see cref="DbTransaction" />.
     /// </summary>
     public interface ISqlSession : IDisposable
     {
         /// <summary>
-        /// An already open <see cref="SqlConnection" /> instance.
+        /// An already open <see cref="DbConnection" /> instance.
         /// </summary>
-        SqlConnection Connection { get; }
+        DbConnection Connection { get; }
 
         /// <summary>
-        /// An active <see cref="SqlTransaction" /> instance.
+        /// An active <see cref="DbTransaction" /> instance.
         /// </summary>
-        SqlTransaction Transaction { get; }
+        DbTransaction Transaction { get; }
 
         /// <summary>
         /// Allows Regalo to signal successful completion, e.g. to allow the transaction to be committed if appropriate.

--- a/Inforigami.Regalo.SqlServer/ISqlSession.cs
+++ b/Inforigami.Regalo.SqlServer/ISqlSession.cs
@@ -1,0 +1,27 @@
+using System;
+
+using Microsoft.Data.SqlClient;
+
+namespace Inforigami.Regalo.SqlServer
+{
+    /// <summary>
+    /// Provides access to an already open <see cref="SqlConnection" /> and <see cref="SqlTransaction" />.
+    /// </summary>
+    public interface ISqlSession : IDisposable
+    {
+        /// <summary>
+        /// An already open <see cref="SqlConnection" /> instance.
+        /// </summary>
+        SqlConnection Connection { get; }
+
+        /// <summary>
+        /// An active <see cref="SqlTransaction" /> instance.
+        /// </summary>
+        SqlTransaction Transaction { get; }
+
+        /// <summary>
+        /// Allows Regalo to signal successful completion, e.g. to allow the transaction to be committed if appropriate.
+        /// </summary>
+        void Complete();
+    }
+}

--- a/Inforigami.Regalo.SqlServer/SqlServerEventStore.cs
+++ b/Inforigami.Regalo.SqlServer/SqlServerEventStore.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Inforigami.Regalo.Core;
 using Inforigami.Regalo.EventSourcing;
 using Inforigami.Regalo.Interfaces;
+
 using Newtonsoft.Json;
 
 namespace Inforigami.Regalo.SqlServer
@@ -69,8 +70,8 @@ namespace Inforigami.Regalo.SqlServer
                 command.CommandType = CommandType.Text;
                 command.CommandText = @"select * from EventStreamEvent where EventStreamId = @eventStreamId and Version <= @Version order by Version;";
 
-                var eventStreamIdParameter = command.Parameters.Add("@EventStreamId", SqlDbType.NVarChar, 1024);
-                var versionParameter     = command.Parameters.Add("@Version", SqlDbType.Int);
+                var eventStreamIdParameter = command.AddParameter("@EventStreamId", DbType.String, 1024);
+                var versionParameter     = command.AddParameter("@Version", DbType.Int32);
 
                 eventStreamIdParameter.Value = eventStreamId;
                 versionParameter.Value = version == EntityVersion.Latest ? int.MaxValue : version;
@@ -139,7 +140,7 @@ namespace Inforigami.Regalo.SqlServer
             eventCommand.CommandType = CommandType.Text;
             eventCommand.CommandText = @"delete from EventStreamEvent where EventStreamId = @EventStreamId;";
 
-            var eventStreamIdParameter = eventCommand.Parameters.Add("@EventStreamId", SqlDbType.NVarChar, 1024);
+            var eventStreamIdParameter = eventCommand.AddParameter("@EventStreamId", DbType.String, 1024);
             eventStreamIdParameter.Value = eventStreamId;
 
             eventCommand.ExecuteNonQuery();
@@ -152,11 +153,11 @@ namespace Inforigami.Regalo.SqlServer
             eventCommand.CommandType = CommandType.Text;
             eventCommand.CommandText = @"delete from EventStream where Id = @EventStreamId and [Version] = @Version;";
 
-            var eventStreamIdParameter = eventCommand.Parameters.Add("@EventStreamId", SqlDbType.NVarChar, 1024);
-            var versionParameter     = eventCommand.Parameters.Add("@Version", SqlDbType.Int);
+            var eventStreamIdParameter = eventCommand.AddParameter("@EventStreamId", DbType.String, 1024);
+            var versionParameter       = eventCommand.AddParameter("@Version", DbType.Int32);
 
             eventStreamIdParameter.Value = eventStreamId;
-            versionParameter.Value     = version;
+            versionParameter.Value       = version;
 
             var rowsDeleted = eventCommand.ExecuteNonQuery();
 
@@ -176,9 +177,9 @@ namespace Inforigami.Regalo.SqlServer
             eventCommand.CommandType = CommandType.Text;
             eventCommand.CommandText = @"insert into EventStreamEvent (EventStreamId, [Version], Data) values (@EventStreamId, @Version, @Data);";
 
-            var eventStreamIdParameter = eventCommand.Parameters.Add("@EventStreamId", SqlDbType.NVarChar, 1024);
-            var versionParameter       = eventCommand.Parameters.Add("@Version", SqlDbType.Int);
-            var dataParameter          = eventCommand.Parameters.Add("@Data", SqlDbType.NVarChar, -1);
+            var eventStreamIdParameter = eventCommand.AddParameter("@EventStreamId", DbType.String, 1024);
+            var versionParameter       = eventCommand.AddParameter("@Version", DbType.Int32);
+            var dataParameter          = eventCommand.AddParameter("@Data", DbType.String, -1);
 
             eventCommand.Prepare();
 
@@ -199,9 +200,9 @@ namespace Inforigami.Regalo.SqlServer
             eventStreamCommand.CommandType = CommandType.Text;
             eventStreamCommand.CommandText = @"update EventStream set Version = @Version where Id = @Id and Version = @ExpectedVersion;";
 
-            eventStreamCommand.Parameters.AddWithValue("@Id", eventStreamId);
-            eventStreamCommand.Parameters.AddWithValue("@Version", newEvents.Last().Version);
-            eventStreamCommand.Parameters.AddWithValue("@ExpectedVersion", expectedVersion);
+            eventStreamCommand.AddParameterWithValue("@Id", eventStreamId);
+            eventStreamCommand.AddParameterWithValue("@Version", newEvents.Last().Version);
+            eventStreamCommand.AddParameterWithValue("@ExpectedVersion", expectedVersion);
 
             int rowsUpdated = eventStreamCommand.ExecuteNonQuery();
 
@@ -223,8 +224,8 @@ namespace Inforigami.Regalo.SqlServer
             eventStreamCommand.CommandType = CommandType.Text;
             eventStreamCommand.CommandText = @"insert into EventStream (Id, [Version]) values (@Id, @Version);";
 
-            eventStreamCommand.Parameters.AddWithValue("@Id", eventStreamId);
-            eventStreamCommand.Parameters.AddWithValue("@Version", newEvents.Last().Version);
+            eventStreamCommand.AddParameterWithValue("@Id", eventStreamId);
+            eventStreamCommand.AddParameterWithValue("@Version", newEvents.Last().Version);
 
             eventStreamCommand.ExecuteNonQuery();
         }

--- a/Inforigami.Regalo.SqlServer/SqlSessionExtensions.cs
+++ b/Inforigami.Regalo.SqlServer/SqlSessionExtensions.cs
@@ -1,0 +1,14 @@
+using Microsoft.Data.SqlClient;
+
+namespace Inforigami.Regalo.SqlServer
+{
+    internal static class SqlSessionExtensions
+    {
+        public static SqlCommand CreateCommand(this ISqlSession sqlSession)
+        {
+            var command = sqlSession.Connection.CreateCommand();
+            command.Transaction = sqlSession.Transaction;
+            return command;
+        }
+    }
+}

--- a/Inforigami.Regalo.SqlServer/SqlSessionExtensions.cs
+++ b/Inforigami.Regalo.SqlServer/SqlSessionExtensions.cs
@@ -1,10 +1,10 @@
-using Microsoft.Data.SqlClient;
+using System.Data.Common;
 
 namespace Inforigami.Regalo.SqlServer
 {
     internal static class SqlSessionExtensions
     {
-        public static SqlCommand CreateCommand(this ISqlSession sqlSession)
+        public static DbCommand CreateCommand(this ISqlSession sqlSession)
         {
             var command = sqlSession.Connection.CreateCommand();
             command.Transaction = sqlSession.Transaction;

--- a/Inforigami.Regalo.SqlServer/TransientSqlSession.cs
+++ b/Inforigami.Regalo.SqlServer/TransientSqlSession.cs
@@ -1,21 +1,22 @@
 using System;
 using System.Data;
+using System.Data.Common;
 
 using Microsoft.Data.SqlClient;
 
 namespace Inforigami.Regalo.SqlServer
 {
     /// <summary>
-    /// Represents an internal <see cref="SqlConnection" /> and <see cref="SqlTransaction" /> that
+    /// Represents an internal <see cref="DbConnection" /> and <see cref="DbTransaction" /> that
     /// are created and managed by Regalo.
     /// </summary>
     internal sealed class TransientSqlSession : ISqlSession
     {
         /// <inheritdoc />
-        public SqlConnection Connection { get; }
+        public DbConnection Connection { get; }
 
         /// <inheritdoc />
-        public SqlTransaction Transaction { get; }
+        public DbTransaction Transaction { get; }
 
         public TransientSqlSession(string connectionString)
         {
@@ -36,7 +37,7 @@ namespace Inforigami.Regalo.SqlServer
             Transaction.Dispose();
         }
 
-        private static (SqlConnection, SqlTransaction) Connect(string connectionString)
+        private static (DbConnection, DbTransaction) Connect(string connectionString)
         {
             var connection = new SqlConnection(connectionString);
             try

--- a/Inforigami.Regalo.SqlServer/TransientSqlSession.cs
+++ b/Inforigami.Regalo.SqlServer/TransientSqlSession.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Data;
+
+using Microsoft.Data.SqlClient;
+
+namespace Inforigami.Regalo.SqlServer
+{
+    /// <summary>
+    /// Represents an internal <see cref="SqlConnection" /> and <see cref="SqlTransaction" /> that
+    /// are created and managed by Regalo.
+    /// </summary>
+    internal sealed class TransientSqlSession : ISqlSession
+    {
+        /// <inheritdoc />
+        public SqlConnection Connection { get; }
+
+        /// <inheritdoc />
+        public SqlTransaction Transaction { get; }
+
+        public TransientSqlSession(string connectionString)
+        {
+            if (connectionString == null) throw new ArgumentNullException("connectionString");
+            (Connection, Transaction) = Connect(connectionString);
+        }
+
+        /// <inheritdoc />
+        public void Complete()
+        {
+            Transaction.Commit();
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            Connection.Dispose();
+            Transaction.Dispose();
+        }
+
+        private static (SqlConnection, SqlTransaction) Connect(string connectionString)
+        {
+            var connection = new SqlConnection(connectionString);
+            try
+            {
+                connection.Open();
+                return (connection, connection.BeginTransaction(IsolationLevel.ReadCommitted));
+            }
+            catch
+            {
+                connection.Dispose();
+                throw;
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Currently

* Regalo manages its own `SqlConnection`.
* Regalo also manages the transaction (using `TransactionScope`).

### With this PR

* If the store is created using a connection string, then Regalo continues to manage its own connection and transaction (although I have switched it to use an explicit ADO.NET transaction, since it made the implementation easier).
* Alternatively, the store can be created with a factory delegate that returns a new interface, `ISqlSession`. This exposes a `DbConnection` and `DbTransaction`, and allows for scenarios where Regalo needs to participate in an externally managed explicit transaction (such as that provided by `NServiceBus.Persistence.Sql`).

### Additional Notes

* I chose to expose `DbConnection` and `DbTransaction` since it's what `NServiceBus.Persistence.Sql` (our use case) exposes itself, plus it wasn't much extra work (and technically might give a bit more flexibility if the `Microsoft.Data.SqlClient` library ever gets replaced again).
* There are two commits in this PR, and it might be easiest to review each in turn.
